### PR TITLE
do not remove the \ if encoding is not unicode or from the preset

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,7 +35,7 @@ const interpretEscapes = (str: string) => {
     if (escapes.hasOwnProperty(type)) {
       return escapes[type];
     }
-    return type;
+    return _;
   });
 }
 


### PR DESCRIPTION
The interpretEscape method is removing the first \ from the quoted strings.
In my use case, for Tensorflow prototxt file, the constant value is encoded with base 8 escape, for
example 0 => \000
since this parser does not handle the type of escape, it is better to leave it as is if the encoding is not recognized.
